### PR TITLE
Fix wait_window_y timeout units so it can fire

### DIFF
--- a/bin/omarchy-dropdown-terminal
+++ b/bin/omarchy-dropdown-terminal
@@ -250,13 +250,15 @@ wait_window_y() {
   local address="$1" target="$2" timeout="$3"
   local deadline now y
 
-  deadline="$(awk -v n="${EPOCHREALTIME:-0}" -v t="$timeout" 'BEGIN { printf "%.0f", n * 1000000 + t * 1000000 }')"
+  deadline="$(awk -v n="${EPOCHREALTIME:-0}" -v t="$timeout" 'BEGIN { printf "%.6f", n + t }')"
   while :; do
     y="$(hyprctl clients -j 2>/dev/null | jq -r --arg address "$address" \
       '.[] | select(.address == $address) | .at[1]' | head -n 1)"
     [[ "$y" =~ ^-?[0-9]+$ ]] && (( y > target - 3 && y < target + 3 )) && return 0
-    now="${EPOCHREALTIME%%.*}"
-    (( now >= deadline )) && return 1
+    now="${EPOCHREALTIME:-0}"
+    if awk -v now="$now" -v deadline="$deadline" 'BEGIN { exit !(now + 0 >= deadline + 0) }'; then
+      return 1
+    fi
     sleep 0.02
   done
 }


### PR DESCRIPTION
Closes #4.

**Root cause:** in `wait_window_y()`, `deadline` was computed in microseconds (`EPOCHREALTIME * 1000000`, ~1.7e15) but `now` was truncated to whole seconds (`1788541525`, ~1.7e9), so the deadline was unreachable. If the window never landed within 2px of target Y (e.g. workspace switch mid-animation), the loop polled `hyprctl` forever while holding the toggle lock, and every later toggle exited 0 as a fake duplicate until the stuck helper was killed.

**Fix:** compare `EPOCHREALTIME` values in the same units (fractional seconds) so the timeout expires.

**Verified:**
- `bash -n` clean.
- Unit test with stubbed `hyprctl` returning `[]` (never matches): `wait_window_y 0xdead 100 0.3` returns 1 after ~0.32s. Old code hangs past a 10s watchdog.
- Live toggle recovers instead of wedging (per #4 repro).